### PR TITLE
Remove landing page redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,7 +38,3 @@
   [headers.values]
     Cache-Control = "max-age=31536000,public,immutable"
 
-[[redirects]]
-  from = "/"
-  to = "/mieco/"
-  status = 302


### PR DESCRIPTION
PR removes the redirect from root to /mieco, since the page is able to go live today