### PR TITLE
Fix broken footer links

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -14,8 +14,8 @@
                         <li><a href="https://blog.mozilla.org/press/">Press Center</a></li>
                         <li><a href="https://blog.mozilla.org/">Corporate Blog</a></li>
 
-                        <li><a href="/en-US/careers/" data-link-type="footer" data-link-name="Careers">Careers</a></li>
-                        <li><a href="/en-US/contact/" data-link-type="footer" data-link-name="Contact">Contact</a></li>
+                        <li><a href="https://mozilla.org/en-US/careers/" data-link-type="footer" data-link-name="Careers">Careers</a></li>
+                        <li><a href="https://mozilla.org/en-US/contact/" data-link-type="footer" data-link-name="Contact">Contact</a></li>
                         <li><a href="https://foundation.mozilla.org/?form=donate">Donate</a></li>
                     </ul>
                 </section>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="mzp-l-content">
         <nav class="mzp-c-footer-primary">
             <div class="mzp-c-footer-primary-logo">
-                <a href="https://mozilla.org">Mozilla</a>
+                <a href="https://www.mozilla.org">Mozilla</a>
             </div>
             <div class="mzp-c-footer-sections">
                 <section class="mzp-c-footer-section">
@@ -10,21 +10,21 @@
                         Company
                     </h5>
                     <ul class="mzp-c-footer-list">
-                        <li><a href="https://mozilla.org/en-US/about/manifesto/">Mozilla Manifesto</a></li>
+                        <li><a href="https://www.mozilla.org/about/manifesto/">Mozilla Manifesto</a></li>
                         <li><a href="https://blog.mozilla.org/press/">Press Center</a></li>
                         <li><a href="https://blog.mozilla.org/">Corporate Blog</a></li>
 
-                        <li><a href="https://mozilla.org/en-US/careers/" data-link-type="footer" data-link-name="Careers">Careers</a></li>
-                        <li><a href="https://mozilla.org/en-US/contact/" data-link-type="footer" data-link-name="Contact">Contact</a></li>
+                        <li><a href="https://www.mozilla.org/careers/" data-link-type="footer" data-link-name="Careers">Careers</a></li>
+                        <li><a href="https://www.mozilla.org/contact/" data-link-type="footer" data-link-name="Contact">Contact</a></li>
                         <li><a href="https://foundation.mozilla.org/?form=donate">Donate</a></li>
                     </ul>
                 </section>
                 <section class="mzp-c-footer-section">
                     <h5 class="mzp-c-footer-heading">Resources</h5>
                     <ul class="mzp-c-footer-list">
-                        <li><a href="https://mozilla.org/en-US/privacy/">Privacy Hub</a></li>
+                        <li><a href="https://www.mozilla.org/privacy/">Privacy Hub</a></li>
 
-                        <li><a href="https://mozilla.org/en-US/firefox/browsers/compare/">Browser Comparison</a></li>
+                        <li><a href="https://www.mozilla.org/firefox/browsers/compare/">Browser Comparison</a></li>
 
                         <li><a href="https://mozilla.design/">Brand Standards</a></li>
                     </ul>
@@ -41,17 +41,17 @@
                 <section class="mzp-c-footer-section">
                     <h5 class="mzp-c-footer-heading">Developers</h5>
                     <ul class="mzp-c-footer-list">
-                        <li><a href="https://mozilla.org/en-US/firefox/developer/" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/developer/" data-link-type="footer"
                                 data-link-name="Firefox Developer Edition">Developer Edition</a></li>
-                        <li><a href="https://mozilla.org/en-US/firefox/channel/desktop/#beta" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/channel/desktop/#beta" data-link-type="footer"
                                 data-link-name="Firefox Beta">Beta</a></li>
-                        <li><a href="https://mozilla.org/en-US/firefox/channel/android/#beta" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/channel/android/#beta" data-link-type="footer"
                                 data-link-name="Firefox Beta for Android">Beta for Android</a></li>
-                        <li><a href="https://mozilla.org/en-US/firefox/channel/desktop/#nightly" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/channel/desktop/#nightly" data-link-type="footer"
                                 data-link-name="Firefox Nightly">Nightly</a></li>
-                        <li><a href="https://mozilla.org/en-US/firefox/channel/android/#nightly" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/channel/android/#nightly" data-link-type="footer"
                                 data-link-name="Firefox Nightly for Android">Nightly for Android</a></li>
-                        <li><a href="https://mozilla.org/en-US/firefox/enterprise/" data-link-type="footer"
+                        <li><a href="https://www.mozilla.org/firefox/enterprise/" data-link-type="footer"
                                 data-link-name="Firefox for Enterprise">Enterprise</a></li>
                         <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer&amp;utm_content=developers"
                                 rel="external" data-link-type="footer" data-link-name="Tools">Tools</a></li>
@@ -93,25 +93,25 @@
         <nav class="mzp-c-footer-secondary">
             <div class="mzp-c-footer-legal">
                 <ul class="mzp-c-footer-terms">
-                    <li><a href="https://mozilla.org/en-US/privacy/websites/" data-link-type="footer" data-link-name="Privacy">Website Privacy
+                    <li><a href="https://www.mozilla.org/privacy/websites/" data-link-type="footer" data-link-name="Privacy">Website Privacy
                             Notice</a></li>
-                    <li><a href="https://mozilla.org/en-US/privacy/websites/#user-choices" data-link-type="footer"
+                    <li><a href="https://www.mozilla.org/privacy/websites/#user-choices" data-link-type="footer"
                             data-link-name="Cookies">Cookies</a></li>
-                    <li><a href="https://mozilla.org/en-US/about/legal/" data-link-type="footer" data-link-name="Legal">Legal</a></li>
-                    <li><a href="https://mozilla.org/en-US/about/governance/policies/participation/" data-link-type="footer"
+                    <li><a href="https://www.mozilla.org/about/legal/" data-link-type="footer" data-link-name="Legal">Legal</a></li>
+                    <li><a href="https://www.mozilla.org/about/governance/policies/participation/" data-link-type="footer"
                             data-link-name="Community Participation Guidelines">Community Participation Guidelines</a></li>
 
-                    <li><a href="https://mozilla.org/en-US/about/this-site/" data-link-type="footer" data-link-name="About this site">About
+                    <li><a href="https://www.mozilla.org/about/this-site/" data-link-type="footer" data-link-name="About this site">About
                             this site</a></li>
                 </ul>
                 <p class="mzp-c-footer-license" rel="license">
 
 
-                    Visit <a href="https://mozilla.org/en-US/">Mozilla Corporation’s</a> not-for-profit parent, the <a
+                    Visit <a href="https://www.mozilla.org/">Mozilla Corporation’s</a> not-for-profit parent, the <a
                         href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=footer"
                         rel="external noopener">Mozilla Foundation</a>.<br>
                     Portions of this content are ©1998–2023 by individual mozilla.org contributors. Content available under
-                    a <a rel="license" href="https://mozilla.org/en-US/foundation/licensing/website-content/">Creative Commons license</a>.
+                    a <a rel="license" href="https://www.mozilla.org/foundation/licensing/website-content/">Creative Commons license</a>.
                 </p>
             </div>
         </nav>


### PR DESCRIPTION
Fixed `Careers` and `Contact` links in footer

issue ref: #39 