### PR TITLE
Move where we set member_name so that it is no longer undefined

### DIFF
--- a/templates/cohort-base.html
+++ b/templates/cohort-base.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 
-{% set member_name %}{% block member_name %}{% endblock %}{% endset %}
 {% block page_css %}<link rel="stylesheet" href="/css/style.scss">{% endblock %}
 {% block page_title %}{% endblock %}
 {% block page_desc %}{% endblock %}
@@ -12,6 +11,7 @@
                 <a href="/mieco">About MIECO</a>
             </li>
             <li aria-current="page" class="mzp-c-breadcrumb-item">
+                {% set member_name %}{% block member_name %}{{ member_name }}{% endblock %}{% endset %}
                 {{ member_name }}
             </li>
         </ol>


### PR DESCRIPTION
This PR is my attempt at fixing the issue where the MIECO participant names are showing up as 'undefined' on their individual pages. 

I was able to resolve this locally by moving where we set the member_name variable to the first time we invoke it (within the breadcrumb menu). 

This seems to resolve it, so opening a PR, but I'm not well-versed in this syntax, so I'm not sure if this is an anti-pattern.